### PR TITLE
lsb_release.py: Minor typo fix in command output

### DIFF
--- a/lsbtools/lsb_release.py
+++ b/lsbtools/lsb_release.py
@@ -80,7 +80,7 @@ if lv == 0 and li == 0 and ld == 0 and lr == 0 and lc == 0:
 
 # Read required configuration file
 if not os.path.exists("/etc/lsb-release"):
-  print("Required configuration file '/etc/lsb-relase' is not found. Exiting...", file=sys.stderr)
+  print("Required configuration file '/etc/lsb-release' is not found. Exiting...", file=sys.stderr)
   sys.exit(1)
 
 conffile = open("/etc/lsb-release", 'r')


### PR DESCRIPTION
While I was looking through this file, I noticed that the filename "/etc/lsb-release" was misspelled in the error output.